### PR TITLE
Fix Discord markdown formatting for player names

### DIFF
--- a/src/main/java/at/shorty/polar/addon/hook/WebhookComposer.java
+++ b/src/main/java/at/shorty/polar/addon/hook/WebhookComposer.java
@@ -64,7 +64,10 @@ public class WebhookComposer {
 
     public String replaceGlobalPlaceholders(String content, User user, Logs logs) {
         Player bukkitPlayer = user.bukkitPlayer().orElse(null);
-        return content.replace("%PLAYER_NAME%", user.username())
+        String username = user.username();
+        String escapedUsername = username.replace("_", "\\\\_");
+        return content.replaceAll("(?<![/=])%PLAYER_NAME%", java.util.regex.Matcher.quoteReplacement(escapedUsername))
+                .replace("%PLAYER_NAME%", username)
                 .replace("%CONTEXT%", logs.getContext())
                 .replace("%PLAYER_UUID%", user.uuid().toString())
                 .replace("%PLAYER_LATENCY%", String.valueOf(user.connection().latency()))

--- a/src/main/java/at/shorty/polar/addon/hook/WebhookComposer.java
+++ b/src/main/java/at/shorty/polar/addon/hook/WebhookComposer.java
@@ -16,6 +16,7 @@ import top.polar.api.user.event.PunishmentEvent;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 @UtilityClass
 public class WebhookComposer {
@@ -66,7 +67,7 @@ public class WebhookComposer {
         Player bukkitPlayer = user.bukkitPlayer().orElse(null);
         String username = user.username();
         String escapedUsername = username.replace("_", "\\\\_");
-        return content.replaceAll("(?<![/=])%PLAYER_NAME%", java.util.regex.Matcher.quoteReplacement(escapedUsername))
+        return content.replaceAll("(?<![/=])%PLAYER_NAME%", Matcher.quoteReplacement(escapedUsername))
                 .replace("%PLAYER_NAME%", username)
                 .replace("%CONTEXT%", logs.getContext())
                 .replace("%PLAYER_UUID%", user.uuid().toString())


### PR DESCRIPTION
Currently, when a player's name contains underscores e.g. `test_player_12` Discord interprets these characters as Markdown formatting in webhook messages. This results in the player's name being rendered in italics and the underscores are completely not shown in the displayed text.

**Solution:**
So I escaped the `_` character (to `\_`) inside the `%PLAYER_NAME%` placeholder replacement to prevent Discord from parsing it as Markdown.